### PR TITLE
Resolve build system warnings

### DIFF
--- a/3rdparty/packagefiles/armadillo-code/meson.build
+++ b/3rdparty/packagefiles/armadillo-code/meson.build
@@ -1,15 +1,28 @@
 project('armadillo', 'cpp',
-    version: '14.1.x',
+    version: '14.0.x',
 )
 
 # Header-only library
 armadillo_inc = include_directories('include')
 
+if get_option('lapack') == 'openblas64'
+  lapack_dep = dependency('openblas64')
+elif get_option('lapack') == 'openblas'
+  lapack_dep = dependency('openblas')
+elif get_option('lapack') == 'lapack64'
+  lapack_dep = dependency('lapack64')
+else # lapack or altas
+  lapack_dep = dependency('lapack')
+endif
+
+
 armadillo_dep = declare_dependency(
     include_directories: armadillo_inc,
+    compile_args: [
+      '-DARMA_DONT_USE_BLAS',
+      '-DARMA_DONT_USE_ARPACK',
+    ],
     dependencies: [
-        dependency('openblas', required: false),
-        dependency('lapack', required: false),
-        dependency('arpack2', required: false),
-    ]
+      lapack_dep,
+    ],
 )

--- a/3rdparty/packagefiles/armadillo-code/meson.options
+++ b/3rdparty/packagefiles/armadillo-code/meson.options
@@ -1,0 +1,11 @@
+option('lapack',
+    description: 'Choose an implementation of the LAPACK solver',
+    type: 'combo',
+    choices: [
+        'openblas64',
+        'openblas',
+        'lapack64',
+        'lapack',
+    ],
+    value: 'openblas',
+)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,4 +1,4 @@
-add_languages('c')
+add_languages('c', native: false)
 
 hdf5_dep = dependency('hdf5', language: 'c', required: false)
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
 project('MicroscPSF', 'cpp',
+    meson_version: '>=1.1',
     license: 'MIT',
     license_files: [
         'LICENSE.txt',


### PR DESCRIPTION
Ensure `meson >= v1.1` . Expose project configuration option `-Darmadillo-code:lapack=openblas` to select the linear solver library.