### PR TITLE
Return the condition number for matrix tuning

### DIFF
--- a/microsc-psf/inc/linsolver.h
+++ b/microsc-psf/inc/linsolver.h
@@ -19,5 +19,12 @@ namespace internal {
  */
 template <bool transpose_b>
 arma::cx_mat solveWithEigen(const arma::mat& A, const arma::cx_mat& b);
+
+/** Recipical condition number of a real-valued matrix.
+ *
+ * Used for algorithm tuning to maximize numerical stability. Otherwise unused
+ * in production code.
+ */
+double rcond(const arma::mat& A);
 }  // namespace internal
 }  // namespace microsc_psf

--- a/microsc-psf/inc/make_psf.h
+++ b/microsc-psf/inc/make_psf.h
@@ -55,5 +55,6 @@ struct scale_t {
 };
 
 arma::Cube<double> makePSF(microscope_params_t, scale_t<Micron> voxel, scale_t<uint32_t> volume,
-                           Micron wavelength = 0.530_um, precision_li2017_t = {});
+                           Micron wavelength = 0.530_um, precision_li2017_t = {},
+                           double* rcond_value = nullptr);
 }  // namespace microsc_psf

--- a/microsc-psf/src/linsolver.cpp
+++ b/microsc-psf/src/linsolver.cpp
@@ -47,6 +47,18 @@ solveWithEigen(const arma::mat& A_buffer, const arma::cx_mat& b_buffer) {
     return xopt_buffer;
 }
 
+double
+rcond(const arma::mat& A_buffer) {
+    using Eigen::JacobiSVD;
+    using Eigen::Map;
+    using Eigen::MatrixXd;
+    const Map<const MatrixXd> A(A_buffer.memptr(), A_buffer.n_rows, A_buffer.n_cols);
+
+    // https://stackoverflow.com/a/33577450
+    const JacobiSVD<MatrixXd> svd(A);
+    return svd.singularValues()(svd.singularValues().size() - 1) / svd.singularValues()(0);
+}
+
 template arma::cx_mat solveWithEigen<true>(const arma::mat&, const arma::cx_mat&);
 template arma::cx_mat solveWithEigen<false>(const arma::mat&, const arma::cx_mat&);
 }  // namespace internal


### PR DESCRIPTION
Given a pointer to a double object, fill in the value of recipocal condition number of the Matrix defined in Li2017.

The `rcond` number is primarily used for offline algorithm numerical stability testing.