### PR TITLE
Update hyperlinks to licenses

### DIFF
--- a/3rdparty/packagefiles/armadillo-code/meson.build
+++ b/3rdparty/packagefiles/armadillo-code/meson.build
@@ -1,5 +1,7 @@
 project('armadillo', 'cpp',
     version: '14.0.x',
+    license: 'Apache',
+    license_files: ['LICENSE.txt'],
 )
 
 # Header-only library

--- a/3rdparty/packagefiles/boost-math/meson.build
+++ b/3rdparty/packagefiles/boost-math/meson.build
@@ -1,5 +1,7 @@
 project('boost-math', 'cpp',
     version: '1.83.0',
+    license: 'BSL-1.0',
+    license_files: ['LICENSE'],
 )
 
 boost_math_inc = include_directories('include')

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,6 @@ project('MicroscPSF', 'cpp',
     license: 'MIT',
     license_files: [
         'LICENSE.txt',
-        #'3rdparty/armadillo-code/LICENSE.txt',
     ],
     subproject_dir: '3rdparty',
     default_options: [


### PR DESCRIPTION
Locate the license files (Apache, BSL-1.0) of the 3rd party dependencies. Meson build system has new plans to install the license files during installation, so we can take advantage of it.

References:
https://mesonbuild.com/Release-notes-for-1-1-0.html#the-project-function-now-supports-setting-the-project-license-files