### PR TITLE
Perform interpolation with multithread

### DIFF
--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-20.04, ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, ubuntu-latest, windows-latest]
 
     steps:
     - name: Fetch sources

--- a/meson.options
+++ b/meson.options
@@ -9,3 +9,8 @@ option('use_eigen',
     type: 'boolean',
     value: false,
 )
+option('use_openmp',
+    description: 'Perform cylindrical frame to Cartesian frame interpolation with multithread',
+    type: 'boolean',
+    value: false,
+)

--- a/microsc-psf/meson.build
+++ b/microsc-psf/meson.build
@@ -32,6 +32,11 @@ else
     use_lapack_args = []
 endif
 
+openmp_dep = get_option('use_openmp') ? [
+    dependency('openmp', language: 'cpp'),
+    dependency('threads'),
+] : []
+
 microsc_psf_lib = static_library('microsc-psf',
     sources: [
         'src/main.cpp',
@@ -48,6 +53,7 @@ microsc_psf_lib = static_library('microsc-psf',
         armadillo_dep,
         boost_math_dep,
         eigen_solver_dep,
+        openmp_dep,
     ],
 )
 
@@ -60,5 +66,6 @@ microsc_psf_dep = declare_dependency(
     ],
     dependencies: [
         armadillo_dep,
+        openmp_dep,
     ],
 )


### PR DESCRIPTION
When the algorithm performs cylindrical frame to Cartesian frame conversion of the (rotational symmetrical) 3D PSF function, each Z-plane's interplation task is independent of each other. Enable the build option `meson configure -Duse_openmp=true` to enable multithreading. 